### PR TITLE
Export non-default ERC20 ABI.

### DIFF
--- a/src/contracts/erc20.ts
+++ b/src/contracts/erc20.ts
@@ -4,7 +4,7 @@ import * as P from 'micro-packed';
 const decimal = P.coders.decimal;
 
 // prettier-ignore
-const ABI = [
+export const ERC20ABI = [
   {type:"function",name:"name",outputs:[{type:"string"}]},{type:"function",name:"totalSupply",outputs:[{type:"uint256"}]},{type:"function",name:"decimals",outputs:[{type:"uint8"}]},{type:"function",name:"symbol",outputs:[{type:"string"}]},{type:"function",name:"approve",inputs:[{name:"spender",type:"address"},{name:"value",type:"uint256"}],outputs:[{name:"success",type:"bool"}]},{type:"function",name:"transferFrom",inputs:[{name:"from",type:"address"},{name:"to",type:"address"},{name:"value",type:"uint256"}],outputs:[{name:"success",type:"bool"}]},{type:"function",name:"balances",inputs:[{type:"address"}],outputs:[{type:"uint256"}]},{type:"function",name:"allowed",inputs:[{type:"address"},{type:"address"}],outputs:[{type:"uint256"}]},{type:"function",name:"balanceOf",inputs:[{name:"owner",type:"address"}],outputs:[{name:"balance",type:"uint256"}]},{type:"function",name:"transfer",inputs:[{name:"to",type:"address"},{name:"value",type:"uint256"}],outputs:[{name:"success",type:"bool"}]},{type:"function",name:"allowance",inputs:[{name:"owner",type:"address"},{name:"spender",type:"address"}],outputs:[{name:"remaining",type:"uint256"}]},{name:"Approval",type:"event",anonymous:false,inputs:[{indexed:true,name:"owner",type:"address"},{indexed:true,name:"spender",type:"address"},{indexed:false,name:"value",type:"uint256"}]},{name:"Transfer",type:"event",anonymous:false,inputs:[{indexed:true,name:"from",type:"address"},{indexed:true,name:"to",type:"address"},{indexed:false,name:"value",type:"uint256"}]}
 ] as const;
 
@@ -48,5 +48,5 @@ export const hints = {
     } from ${v.from} to ${v.to}`;
   },
 };
-addHints(ABI, hints);
-export default ABI;
+addHints(ERC20ABI, hints);
+export default ERC20ABI;


### PR DESCRIPTION
Default exports are difficult to discover.  Instead, export well named items from each library, keeping in mind that users of the library will be doing `import { name } from 'package'`.

In this case, naming the variable `ERC20ABI` provides additional clarity since it will be common to import several ABIs.  If the user wants to change the name, they can do `import { ERC20ABI as whatever } from 'library'`.

Note: I personally prefer `Erc20Abi`, but it appears the style in this repository is all caps for acronyms so I have followed that in this PR.